### PR TITLE
refactor: global classes and methods to public

### DIFF
--- a/force-app/src/classes/Argument.cls
+++ b/force-app/src/classes/Argument.cls
@@ -16,12 +16,12 @@
  */
 @IsTest
 @SuppressWarnings('PMD.EmptyStatementBlock')
-global class Argument {
-  global interface Matchable {
+public class Argument {
+  public interface Matchable {
     Boolean matches(Object callArgument);
   }
 
-  global class ConfigurationException extends Exception {
+  public class ConfigurationException extends Exception {
   }
 
   private Argument() {
@@ -46,31 +46,31 @@ global class Argument {
     return true;
   }
 
-  global static List<Argument.Matchable> empty() {
+  public static List<Argument.Matchable> empty() {
     return new List<Argument.Matchable>();
   }
 
-  global static List<Argument.Matchable> of(final Object arg) {
+  public static List<Argument.Matchable> of(final Object arg) {
     return Argument.ofList(new List<Object>{ arg });
   }
 
-  global static List<Argument.Matchable> of(final Object arg1, final Object arg2) {
+  public static List<Argument.Matchable> of(final Object arg1, final Object arg2) {
     return Argument.ofList(new List<Object>{ arg1, arg2 });
   }
 
-  global static List<Argument.Matchable> of(final Object arg1, final Object arg2, final Object arg3) {
+  public static List<Argument.Matchable> of(final Object arg1, final Object arg2, final Object arg3) {
     return Argument.ofList(new List<Object>{ arg1, arg2, arg3 });
   }
 
-  global static List<Argument.Matchable> of(final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
+  public static List<Argument.Matchable> of(final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
     return Argument.ofList(new List<Object>{ arg1, arg2, arg3, arg4 });
   }
 
-  global static List<Argument.Matchable> of(final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
+  public static List<Argument.Matchable> of(final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
     return Argument.ofList(new List<Object>{ arg1, arg2, arg3, arg4, arg5 });
   }
 
-  global static List<Argument.Matchable> ofList(final List<Object> listOfArgs) {
+  public static List<Argument.Matchable> ofList(final List<Object> listOfArgs) {
     final List<Argument.Matchable> listOfMatchableArgs = Argument.empty();
     if (listOfArgs == null) {
       return listOfMatchableArgs;
@@ -85,27 +85,27 @@ global class Argument {
     return listOfMatchableArgs;
   }
 
-  global static Argument.Matchable any() {
+  public static Argument.Matchable any() {
     return new AnyMatchable();
   }
 
-  global static Argument.Matchable equals(final Object callArgument) {
+  public static Argument.Matchable equals(final Object callArgument) {
     return new EqualsMatchable(callArgument);
   }
 
-  global static Argument.Matchable jsonEquals(final Object callArgument) {
+  public static Argument.Matchable jsonEquals(final Object callArgument) {
     return new JSONMatchable(callArgument);
   }
 
-  global static Argument.Matchable ofType(final String matchingType) {
+  public static Argument.Matchable ofType(final String matchingType) {
     return new TypeMatchable(matchingType);
   }
 
-  global static Argument.Matchable ofType(final Schema.SObjectType callArgument) {
+  public static Argument.Matchable ofType(final Schema.SObjectType callArgument) {
     return new TypeMatchable(callArgument);
   }
 
-  global static Argument.Matchable ofType(final Type callArgument) {
+  public static Argument.Matchable ofType(final Type callArgument) {
     return new TypeMatchable(callArgument);
   }
 

--- a/force-app/src/classes/Expect.cls
+++ b/force-app/src/classes/Expect.cls
@@ -5,8 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 @IsTest
-global class Expect {
-  global interface MethodSpyExpectable {
+public class Expect {
+  public interface MethodSpyExpectable {
     /**
      * Assert that a method spy has never been called
      */
@@ -51,11 +51,11 @@ global class Expect {
     void hasBeenLastCalledWith(final Object param1, final Object param2, final Object param3, final Object param4, final Object param5);
   }
 
-  global interface ErrorMessage {
+  public interface ErrorMessage {
     String toString();
   }
 
-  global interface Asserter {
+  public interface Asserter {
     void isTrue(Boolean value, ErrorMessage message);
     void isFalse(Boolean value, ErrorMessage message);
   }
@@ -66,7 +66,7 @@ global class Expect {
    * @param spy the MethodSpy to assert
    * @see       MethodSpy
    */
-  global static MethodSpyExpectable that(MethodSpy spy) {
+  public static MethodSpyExpectable that(MethodSpy spy) {
     return that(spy, METHOD_SPY_ASSERTER);
   }
 

--- a/force-app/src/classes/MethodSpy.cls
+++ b/force-app/src/classes/MethodSpy.cls
@@ -15,16 +15,16 @@
  *  @see Matchable
  */
 @IsTest
-global class MethodSpy {
-  global String methodName { get; private set; }
-  global CallLog callLog { get; private set; }
+public class MethodSpy {
+  public String methodName { get; private set; }
+  public CallLog callLog { get; private set; }
   private List<ParameterizedMethodSpyCall> parameterizedMethodCalls = new List<ParameterizedMethodSpyCall>();
   private Object returnValue;
   private Boolean configuredGlobalReturn = false;
   private Boolean configuredGlobalThrow = false;
   private Exception exceptionToThrow;
 
-  global MethodSpy(String methodName) {
+  public MethodSpy(String methodName) {
     this.methodName = methodName;
     this.callLog = new CallLog();
   }
@@ -56,39 +56,39 @@ global class MethodSpy {
     throw new ConfigurationExceptionBuilder().withMethodSpy(this).withCallArguments(args).build();
   }
 
-  global void returns(Object value) {
+  public void returns(Object value) {
     this.configuredGlobalReturn = true;
     this.configuredGlobalThrow = false;
     this.returnValue = value;
   }
 
-  global void throwsException(Exception exceptionToThrow) {
+  public void throwsException(Exception exceptionToThrow) {
     this.configuredGlobalThrow = true;
     this.configuredGlobalReturn = false;
     this.exceptionToThrow = exceptionToThrow;
   }
 
-  global MethodSpyCall whenCalledWith() {
+  public MethodSpyCall whenCalledWith() {
     return this.whenCalledWithArguments(Argument.empty());
   }
 
-  global MethodSpyCall whenCalledWith(final Object arg) {
+  public MethodSpyCall whenCalledWith(final Object arg) {
     return this.whenCalledWithArguments((arg instanceof List<Argument.Matchable>) ? (List<Argument.Matchable>) arg : Argument.of(arg));
   }
 
-  global MethodSpyCall whenCalledWith(final Object arg1, final Object arg2) {
+  public MethodSpyCall whenCalledWith(final Object arg1, final Object arg2) {
     return this.whenCalledWithArguments(Argument.of(arg1, arg2));
   }
 
-  global MethodSpyCall whenCalledWith(final Object arg1, final Object arg2, final Object arg3) {
+  public MethodSpyCall whenCalledWith(final Object arg1, final Object arg2, final Object arg3) {
     return this.whenCalledWithArguments(Argument.of(arg1, arg2, arg3));
   }
 
-  global MethodSpyCall whenCalledWith(final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
+  public MethodSpyCall whenCalledWith(final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
     return this.whenCalledWithArguments(Argument.of(arg1, arg2, arg3, arg4));
   }
 
-  global MethodSpyCall whenCalledWith(final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
+  public MethodSpyCall whenCalledWith(final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
     return this.whenCalledWithArguments(Argument.of(arg1, arg2, arg3, arg4, arg5));
   }
 
@@ -130,7 +130,7 @@ global class MethodSpy {
     }
   }
 
-  global interface MethodSpyCall {
+  public interface MethodSpyCall {
     void thenReturn(Object value);
     void thenThrow(Exception error);
   }
@@ -194,6 +194,6 @@ global class MethodSpy {
     }
   }
 
-  global class ConfigurationException extends Exception {
+  public class ConfigurationException extends Exception {
   }
 }

--- a/force-app/src/classes/Mock.cls
+++ b/force-app/src/classes/Mock.cls
@@ -5,15 +5,15 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 @isTest
-global class Mock implements System.StubProvider {
-  global Object stub { get; set; }
+public class Mock implements System.StubProvider {
+  public Object stub { get; set; }
   private Map<String, MethodSpy> spies = new Map<String, MethodSpy>();
 
   private Mock(final Type aType, final StubBuilder stubBuilder) {
     this.stub = stubBuilder.build(aType, this);
   }
 
-  global Object handleMethodCall(
+  public Object handleMethodCall(
     Object stubbedObject,
     String stubbedMethodName,
     Type returnType,
@@ -30,26 +30,26 @@ global class Mock implements System.StubProvider {
     return result;
   }
 
-  global MethodSpy spyOn(final String methodName) {
+  public MethodSpy spyOn(final String methodName) {
     if (!this.spies.containsKey(methodName)) {
       this.spies.put(methodName, new MethodSpy(methodName));
     }
     return this.getSpy(methodName);
   }
 
-  global MethodSpy getSpy(final String methodName) {
+  public MethodSpy getSpy(final String methodName) {
     return this.spies.get(methodName);
   }
 
-  global static Mock forType(final Type aType) {
+  public static Mock forType(final Type aType) {
     return Mock.forType(aType, new DefaultStubBuilder());
   }
 
-  global static Mock forType(final Type aType, final StubBuilder stubBuilder) {
+  public static Mock forType(final Type aType, final StubBuilder stubBuilder) {
     return new Mock(aType, stubBuilder);
   }
 
-  global interface StubBuilder {
+  public interface StubBuilder {
     Object build(final Type aType, System.StubProvider stubProvider);
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This Pull Request proposes changing the access modifier of the global class and methods from "global" to "public" to enhance the package's flexibility and maintainability.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current "global" access modifier in the 1GP package restricts interface changes and the removal of classes and methods after release, posing a potential risk. By switching to the "public" access modifier, we can ensure future modifications without breaking compatibility or causing issues for users. This change aligns the package with best practices and provides a safer and more extensible solution.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
